### PR TITLE
Allow Booting CAT-DEV's

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -96,19 +96,19 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: sprig_amd64.deb
-          path: installer-scripts/unix/sprig_0.0.3_amd64.deb
+          path: installer-scripts/unix/sprig_0.0.4_amd64.deb
       - uses: actions/upload-artifact@v3
         with:
           name: sprig_amd64.rpm
-          path: installer-scripts/unix/sprig-0.0.3-1.x86_64.rpm
+          path: installer-scripts/unix/sprig-0.0.4-1.x86_64.rpm
       - uses: actions/upload-artifact@v3
         with:
           name: sprig_amd64.apk
-          path: installer-scripts/unix/sprig_0.0.3_x86_64.apk
+          path: installer-scripts/unix/sprig_0.0.4_x86_64.apk
       - uses: actions/upload-artifact@v3
         with:
           name: sprig_amd64.pkg.tar.zst
-          path: installer-scripts/unix/sprig-0.0.3-1-x86_64.pkg.tar.zst
+          path: installer-scripts/unix/sprig-0.0.4-1-x86_64.pkg.tar.zst
       - uses: actions/upload-artifact@v3
         with:
           name: sprig-target-directory-unix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,12 +208,12 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bridgectl"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "cat-dev",
  "clap",
  "fnv",
- "log 0.0.3",
+ "log 0.0.4",
  "mac_address",
  "miette",
  "once_cell",
@@ -237,7 +237,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cat-dev"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bytes",
  "configparser",
@@ -429,7 +429,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "findbridge"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "cat-dev",
  "mac_address",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "getbridgeconfig"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "cat-dev",
  "tokio",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "console-subscriber",
  "miette",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "mionparamspace"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "cat-dev",
  "time",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "mionps"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "cat-dev",
  "time",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "setbridgeconfig"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "cat-dev",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "async-stream"
@@ -99,7 +99,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -110,7 +110,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -260,12 +260,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 
 [[package]]
 name = "cfg-if"
@@ -307,7 +304,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -377,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -518,7 +515,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -588,7 +585,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -628,9 +625,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
@@ -720,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -803,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "mac_address"
@@ -874,7 +871,7 @@ checksum = "f301c3f54f98abc6c212ee722f5e5c62e472a334415840669e356f04850051ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -900,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -935,7 +932,7 @@ checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
 dependencies = [
  "byteorder",
  "libc",
- "log 0.4.20",
+ "log 0.4.21",
  "neli-proc-macros",
 ]
 
@@ -1095,7 +1092,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1151,7 +1148,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1282,9 +1279,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "scopeguard"
@@ -1294,29 +1291,29 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -1384,12 +1381,12 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1432,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.49"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1449,9 +1446,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1497,14 +1494,14 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1567,7 +1564,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1673,7 +1670,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1702,7 +1699,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log 0.4.20",
+ "log 0.4.21",
  "once_cell",
  "tracing-core",
 ]
@@ -1870,7 +1867,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1890,17 +1887,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -1911,9 +1908,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1923,9 +1920,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1935,9 +1932,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1947,9 +1944,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1959,9 +1956,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1971,9 +1968,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1983,6 +1980,6 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ authors = ["Cynthia <cynthia@coan.dev>"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/rem-verse/sprig"
-version = "0.0.3"
+version = "0.0.4"
 
 [profile.release]
 codegen-units = 1

--- a/cmd/bridgectl/src/commands/boot.rs
+++ b/cmd/bridgectl/src/commands/boot.rs
@@ -1,0 +1,346 @@
+//! Perform booting of a cat-dev bridge.
+//!
+//! TODO(mythra): not fully implemented yet.
+
+use crate::{
+	commands::argv_helpers::{coalesce_bridge_arguments, get_default_bridge},
+	exit_codes::{
+		BOOT_CGI_FAILURE, BOOT_NO_AVAILABLE_BRIDGE, BOOT_NO_BRIDGE_FILTERS, NOT_YET_IMPLEMENTED,
+	},
+	knobs::env::{BRIDGE_CURRENT_IP_ADDRESS, BRIDGE_CURRENT_NAME},
+	utils::add_context_to,
+};
+use cat_dev::mion::{
+	cgis::very_hacky_will_break_dont_use_power_on,
+	discovery::{find_mion, MIONFindBy},
+};
+use mac_address::MacAddress;
+use miette::miette;
+use std::{net::Ipv4Addr, path::PathBuf, time::Duration};
+use tracing::{error, field::valuable, info, warn};
+
+pub async fn handle_boot(
+	use_json: bool,
+	just_fetch_default: bool,
+	bridge_flag_arguments: (Option<Ipv4Addr>, Option<String>, Option<String>),
+	bridge_argv: Option<String>,
+	find_by_args: (Duration, u16),
+	host_state_path: Option<PathBuf>,
+	no_pcfs: bool,
+) {
+	let bridge_ip = get_bridge_ip(
+		use_json,
+		just_fetch_default,
+		bridge_flag_arguments,
+		bridge_argv,
+		find_by_args,
+		host_state_path,
+	)
+	.await;
+
+	if no_pcfs {
+		warn!("NOTE: this will work if the cat-dev hasn't been taken control of by another host, but does not have good error handling yet!");
+		match very_hacky_will_break_dont_use_power_on(bridge_ip).await {
+			Ok(result_code) => {
+				if result_code {
+					info!("Successfully powered on MION!");
+				} else {
+					error!("Failed to boot cat-dev bridge! Please reach out for support!");
+					std::process::exit(BOOT_CGI_FAILURE);
+				}
+			}
+			Err(cause) => {
+				if use_json {
+					error!(
+						id = "bridgectl::boot::failed_to_boot_device",
+						bridge.ip = %bridge_ip,
+						?cause,
+						suggestions = valuable(&[
+						  "Please file an issue, and reach out!"
+						]),
+					);
+				} else {
+					error!(
+				  	"\n{:?}",
+				  	miette!(
+				  		help = "PLEASE PLEASE PLEASE FILE AN ISSUE!",
+				  		"Failure to perform hacky non-emulated boot!!! THIS IS STILL EARLY !!! PLEASE FILE AN ISSUE!\n {cause:?}",
+				  	),
+				  );
+				}
+
+				std::process::exit(BOOT_CGI_FAILURE);
+			}
+		}
+	} else {
+		error!("Sorry! THIS HAS NOT YET BEEN IMPLEMENTED! FSEMUL IS MAKING ME CRY!");
+		std::process::exit(NOT_YET_IMPLEMENTED);
+	}
+}
+
+async fn get_bridge_ip(
+	use_json: bool,
+	just_fetch_default: bool,
+	bridge_flag_arguments: (Option<Ipv4Addr>, Option<String>, Option<String>),
+	bridge_argv: Option<String>,
+	find_by_args: (Duration, u16),
+	host_state_path: Option<PathBuf>,
+) -> Ipv4Addr {
+	let did_specify_cli_arg = bridge_argv.is_some();
+	if let Some((filter_ip, filter_mac, filter_name)) = coalesce_bridge_arguments(
+		use_json,
+		just_fetch_default,
+		bridge_flag_arguments,
+		bridge_argv,
+		did_specify_cli_arg,
+	) {
+		if filter_ip.is_none() && filter_mac.is_none() && filter_name.is_none() {
+			if let Some(ip) = BRIDGE_CURRENT_IP_ADDRESS.as_ref() {
+				*ip
+			} else if let Some(bn) = BRIDGE_CURRENT_NAME.as_ref() {
+				get_mochiato_bridge_ip(use_json, bn, find_by_args).await
+			} else if use_json {
+				error!(
+					id = "bridgectl::boot::no_bridge_filters",
+					help = "You didn't specify any bridge to get the information of!",
+				);
+				std::process::exit(BOOT_NO_BRIDGE_FILTERS);
+			} else {
+				error!(
+					"\n{:?}",
+					miette!(
+						help = "See `bridgectl boot --help` for more information!",
+						"You didn't specify any bridge to get the information of!",
+					),
+				);
+				std::process::exit(BOOT_NO_BRIDGE_FILTERS);
+			}
+		} else {
+			find_bridge_ip_from_args(use_json, filter_ip, filter_mac, filter_name, find_by_args)
+				.await
+		}
+	} else {
+		get_default_bridge_ip(use_json, host_state_path, find_by_args).await
+	}
+}
+
+async fn find_bridge_ip_from_args(
+	use_json: bool,
+	filter_ip: Option<Ipv4Addr>,
+	filter_mac: Option<MacAddress>,
+	filter_name: Option<String>,
+	find_by_args: (Duration, u16),
+) -> Ipv4Addr {
+	if let Some(ip) = filter_ip {
+		return ip;
+	}
+
+	match find_mion(
+		if let Some(mac) = filter_mac {
+			MIONFindBy::MacAddress(mac)
+		} else {
+			MIONFindBy::Name(filter_name.clone().unwrap_or_default())
+		},
+		false,
+		Some(find_by_args.0),
+		Some(find_by_args.1),
+	)
+	.await
+	{
+		Ok(Some(identity)) => identity.ip_address(),
+		Ok(None) => {
+			if use_json {
+				error!(
+				  id = "bridgectl::boot::set_failed_to_find_a_device",
+				  filter.ip = ?filter_ip,
+				  filter.mac = ?filter_mac,
+				  filter.name = ?filter_name,
+				  suggestions = valuable(&[
+					  "Please ensure the CAT-DEV you're trying to find is powered on, and running.",
+					  "Make sure you are on the same Local Network, Subnet, and VLAN as the CAT-DEV device.",
+					  "If you're not on the same VLAN, Subnet you can use something like: <https://github.com/udp-redux/udp-broadcast-relay-redux> to forward between the subnets & vlans.",
+					  "Ensure your filters line up with a single CAT-DEV device.",
+				  ]),
+				);
+			} else {
+				error!(
+  				"\n{:?}",
+  				add_context_to(
+  					miette!(
+  						"Failed to find bridge that matched the series of filters, cannot boot.",
+  					),
+  					[
+  						miette!("Please ensure the CAT-DEV you're trying to find is powered on, and running."),
+  						miette!("Make sure you are on the same Local Network, Subnet, and VLAN as the CAT-DEV device."),
+  						miette!("If you're not on the same VLAN, Subnet you can use something like: <https://github.com/udp-redux/udp-broadcast-relay-redux> to forward between the subnets & vlans."),
+  						miette!(
+  							help = format!("Current Filter State: Bridge Filter IP: {filter_ip:?} / Bridge Filter Mac: {filter_mac:?} / Bridge Filter Name: {filter_name:?}"),
+  							"Ensure your filters line up with a single CAT-DEV device.",
+  						),
+  					].into_iter(),
+  				),
+  			);
+			}
+			std::process::exit(BOOT_NO_AVAILABLE_BRIDGE);
+		}
+		Err(cause) => {
+			if use_json {
+				error!(
+  				id = "bridgectl::boot::failed_to_execute_broadcast",
+  				?cause,
+  				help = "Could not setup sockets to broadcast and search for the MION you specified; perhaps another program is already using the single MION port?",
+  			);
+			} else {
+				error!(
+					"\n{:?}",
+					miette!(
+  					help = "Perhaps another program is already using the single MION port?",
+  					"Could not setup sockets to broadcast and search for the MION you specified.",
+  				)
+					.wrap_err(cause),
+				);
+			}
+			std::process::exit(BOOT_NO_AVAILABLE_BRIDGE);
+		}
+	}
+}
+
+async fn get_mochiato_bridge_ip(
+	use_json: bool,
+	bridge_name: &str,
+	find_by_args: (Duration, u16),
+) -> Ipv4Addr {
+	match find_mion(
+		MIONFindBy::Name(bridge_name.to_owned()),
+		false,
+		Some(find_by_args.0),
+		Some(find_by_args.1),
+	)
+	.await
+	{
+		Ok(Some(identity)) => identity.ip_address(),
+		Ok(None) => {
+			if use_json {
+				error!(
+					  id = "bridgectl::boot::failed_to_find_ip_of_mochiato_bridge",
+					  bridge.name = bridge_name,
+					  suggestions = valuable(&[
+						  "Please ensure the default CAT-DEV you're trying to find is powered on, and running.",
+						  "Make sure you are on the same Local Network, Subnet, and VLAN as the CAT-DEV device.",
+						  "If you're not on the same VLAN, Subnet you can use something like: <https://github.com/udp-redux/udp-broadcast-relay-redux> to forward between the subnets & vlans.",
+						  "Ensure `cafe`/`cafex`/`mochiato` has been loaded with the latest information.",
+					  ]),
+					);
+			} else {
+				error!(
+						"\n{:?}",
+						add_context_to(
+							miette!(
+								"Failed to find the `cafe`/`cafex`/`mochiato` bridge's ip by broadcasting, and was not specified, cannot boot device.",
+							),
+							[
+								miette!("Please ensure the default CAT-DEV you're trying to find is powered on, and running."),
+								miette!("Make sure you are on the same Local Network, Subnet, and VLAN as the CAT-DEV device."),
+								miette!("If you're not on the same VLAN, Subnet you can use something like: <https://github.com/udp-redux/udp-broadcast-relay-redux> to forward between the subnets & vlans."),
+								miette!("Ensure `cafe`/`cafex`/`mochiato` has been loaded with the latest information."),
+							].into_iter(),
+						),
+					);
+			}
+			std::process::exit(BOOT_NO_AVAILABLE_BRIDGE);
+		}
+		Err(cause) => {
+			if use_json {
+				error!(
+						id = "bridgectl::boot::failed_to_execute_broadcast",
+						?cause,
+						help = "Could not setup sockets to broadcast and search for the default MION; perhaps another program is already using the single MION port?",
+					);
+			} else {
+				error!(
+					"\n{:?}",
+					miette!(
+						help = "Perhaps another program is already using the single MION port?",
+						"Could not setup sockets to broadcast and search for the default MION.",
+					)
+					.wrap_err(cause),
+				);
+			}
+			std::process::exit(BOOT_NO_AVAILABLE_BRIDGE);
+		}
+	}
+}
+
+async fn get_default_bridge_ip(
+	use_json: bool,
+	host_state_path: Option<PathBuf>,
+	find_by_args: (Duration, u16),
+) -> Ipv4Addr {
+	let (default_bridge_name, opt_ip) = get_default_bridge(use_json, host_state_path.clone()).await;
+	if let Some(ip) = opt_ip {
+		ip
+	} else {
+		match find_mion(
+			MIONFindBy::Name(default_bridge_name.clone()),
+			false,
+			Some(find_by_args.0),
+			Some(find_by_args.1),
+		)
+		.await
+		{
+			Ok(Some(identity)) => identity.ip_address(),
+			Ok(None) => {
+				if use_json {
+					error!(
+					  id = "bridgectl::boot::failed_to_find_ip_of_default_bridge",
+					  bridge.name = default_bridge_name,
+					  suggestions = valuable(&[
+						  "Please ensure the default CAT-DEV you're trying to find is powered on, and running.",
+						  "Make sure you are on the same Local Network, Subnet, and VLAN as the CAT-DEV device.",
+						  "If you're not on the same VLAN, Subnet you can use something like: <https://github.com/udp-redux/udp-broadcast-relay-redux> to forward between the subnets & vlans.",
+						  "Ensure your filters line up with a single CAT-DEV device.",
+					  ]),
+					);
+				} else {
+					error!(
+						"\n{:?}",
+						add_context_to(
+							miette!(
+								"Failed to find the default bridge's ip since the configuration file did not have it, cannot boot.",
+							),
+							[
+								miette!("Please ensure the default CAT-DEV you're trying to find is powered on, and running."),
+								miette!("Make sure you are on the same Local Network, Subnet, and VLAN as the CAT-DEV device."),
+								miette!("If you're not on the same VLAN, Subnet you can use something like: <https://github.com/udp-redux/udp-broadcast-relay-redux> to forward between the subnets & vlans."),
+								miette!(
+									help = format!("Bridge Filter Path: {host_state_path:?}"),
+									"Ensure your filters line up with a single CAT-DEV device.",
+								),
+							].into_iter(),
+						),
+					);
+				}
+				std::process::exit(BOOT_NO_AVAILABLE_BRIDGE);
+			}
+			Err(cause) => {
+				if use_json {
+					error!(
+						id = "bridgectl::boot::failed_to_execute_broadcast",
+						?cause,
+						help = "Could not setup sockets to broadcast and search for the default MION; perhaps another program is already using the single MION port?",
+					);
+				} else {
+					error!(
+						"\n{:?}",
+						miette!(
+							help = "Perhaps another program is already using the single MION port?",
+							"Could not setup sockets to broadcast and search for the default MION.",
+						)
+						.wrap_err(cause),
+					);
+				}
+				std::process::exit(BOOT_NO_AVAILABLE_BRIDGE);
+			}
+		}
+	}
+}

--- a/cmd/bridgectl/src/commands/get_parameters.rs
+++ b/cmd/bridgectl/src/commands/get_parameters.rs
@@ -13,16 +13,25 @@ use cat_dev::mion::{
 	proto::parameter::DumpedMionParameters,
 };
 use miette::miette;
-use std::{net::Ipv4Addr, path::PathBuf};
+use std::{net::Ipv4Addr, path::PathBuf, time::Duration};
 use tracing::{debug, error, field::valuable, info};
 
 /// Actual command handler for the `get-parameters`, or `gp` command.
+#[allow(
+	// This is unfortunate that there are a lot, but the command accepts lots of
+	// potential parameters.
+	//
+	// The parameters are also fairly different types, so the chances of screwing
+	// up passing them in without noticing is low.
+	clippy::too_many_arguments,
+)]
 pub async fn handle_get_parameters(
 	use_json: bool,
 	just_fetch_default: bool,
 	bridge_flag_arguments: (Option<Ipv4Addr>, Option<String>, Option<String>),
 	bridge_or_params_arguments: Option<String>,
 	only_params_arguments: Option<String>,
+	find_by_args: (Duration, u16),
 	parameter_space_port: Option<u16>,
 	host_state_path: Option<PathBuf>,
 ) {
@@ -64,6 +73,7 @@ pub async fn handle_get_parameters(
 		bridge_flag_arguments,
 		bridge_name_arg,
 		had_params_arg,
+		find_by_args,
 		host_state_path,
 	)
 	.await;
@@ -154,6 +164,7 @@ async fn get_a_bridge_ip(
 	bridge_flag_arguments: (Option<Ipv4Addr>, Option<String>, Option<String>),
 	bridge_or_params_argument: Option<String>,
 	had_params_arg: bool,
+	find_by_args: (Duration, u16),
 	host_state_path: Option<PathBuf>,
 ) -> Ipv4Addr {
 	if let Some((filter_ip, filter_mac, filter_name)) = coalesce_bridge_arguments(
@@ -167,7 +178,7 @@ async fn get_a_bridge_ip(
 			if let Some(ip_address) = *BRIDGE_CURRENT_IP_ADDRESS {
 				return ip_address;
 			} else if let Some(name) = BRIDGE_CURRENT_NAME.as_deref() {
-				return get_mochiato_bridge_ip(use_json, name).await;
+				return get_mochiato_bridge_ip(use_json, name, find_by_args).await;
 			} else if use_json {
 				error!(
 					id = "bridgectl::get_parameters::no_bridge_filters",
@@ -197,7 +208,8 @@ async fn get_a_bridge_ip(
 				MIONFindBy::Name(filter_name.clone().unwrap_or_default())
 			},
 			false,
-			None,
+			Some(find_by_args.0),
+			Some(find_by_args.1),
 		)
 		.await
 		{
@@ -258,12 +270,23 @@ async fn get_a_bridge_ip(
 			}
 		}
 	} else {
-		get_default_bridge_ip(use_json, host_state_path).await
+		get_default_bridge_ip(use_json, host_state_path, find_by_args).await
 	}
 }
 
-async fn get_mochiato_bridge_ip(use_json: bool, bridge_name: &str) -> Ipv4Addr {
-	match find_mion(MIONFindBy::Name(bridge_name.to_owned()), false, None).await {
+async fn get_mochiato_bridge_ip(
+	use_json: bool,
+	bridge_name: &str,
+	find_by_args: (Duration, u16),
+) -> Ipv4Addr {
+	match find_mion(
+		MIONFindBy::Name(bridge_name.to_owned()),
+		false,
+		Some(find_by_args.0),
+		Some(find_by_args.1),
+	)
+	.await
+	{
 		Ok(Some(identity)) => identity.ip_address(),
 		Ok(None) => {
 			if use_json {
@@ -317,12 +340,23 @@ async fn get_mochiato_bridge_ip(use_json: bool, bridge_name: &str) -> Ipv4Addr {
 	}
 }
 
-async fn get_default_bridge_ip(use_json: bool, host_state_path: Option<PathBuf>) -> Ipv4Addr {
+async fn get_default_bridge_ip(
+	use_json: bool,
+	host_state_path: Option<PathBuf>,
+	find_by_args: (Duration, u16),
+) -> Ipv4Addr {
 	let (default_bridge_name, opt_ip) = get_default_bridge(use_json, host_state_path.clone()).await;
 	if let Some(ip) = opt_ip {
 		ip
 	} else {
-		match find_mion(MIONFindBy::Name(default_bridge_name.clone()), false, None).await {
+		match find_mion(
+			MIONFindBy::Name(default_bridge_name.clone()),
+			false,
+			Some(find_by_args.0),
+			Some(find_by_args.1),
+		)
+		.await
+		{
 			Ok(Some(identity)) => identity.ip_address(),
 			Ok(None) => {
 				if use_json {

--- a/cmd/bridgectl/src/commands/mod.rs
+++ b/cmd/bridgectl/src/commands/mod.rs
@@ -4,6 +4,7 @@
 mod argv_helpers;
 
 mod add;
+mod boot;
 mod dump_parameters;
 mod get;
 mod get_parameters;
@@ -14,6 +15,7 @@ mod set_default;
 mod set_parameters;
 
 pub use add::*;
+pub use boot::*;
 pub use dump_parameters::*;
 pub use get::*;
 pub use get_parameters::*;

--- a/cmd/bridgectl/src/commands/set_parameters.rs
+++ b/cmd/bridgectl/src/commands/set_parameters.rs
@@ -14,16 +14,25 @@ use cat_dev::mion::{
 	proto::parameter::well_known::ParameterLocationSpecification,
 };
 use miette::miette;
-use std::{net::Ipv4Addr, path::PathBuf};
+use std::{net::Ipv4Addr, path::PathBuf, time::Duration};
 use tracing::{error, field::valuable, info};
 
 /// Actual command handler for the `set-parameters`, or `sp` command.
+#[allow(
+	// This is unfortunate that there are a lot, but the command accepts lots of
+	// potential parameters.
+	//
+	// The parameters are also fairly different types, so the chances of screwing
+	// up passing them in without noticing is low.
+	clippy::too_many_arguments,
+)]
 pub async fn handle_set_parameters(
 	use_json: bool,
 	just_fetch_default: bool,
 	bridge_flag_arguments: (Option<Ipv4Addr>, Option<String>, Option<String>),
 	bridge_or_params_arguments: Option<String>,
 	only_params_arguments: Option<String>,
+	find_by_args: (Duration, u16),
 	parameter_space_port: Option<u16>,
 	host_state_path: Option<PathBuf>,
 ) {
@@ -66,6 +75,7 @@ pub async fn handle_set_parameters(
 		bridge_flag_arguments,
 		bridge_name_arg,
 		had_params_arg,
+		find_by_args,
 		host_state_path,
 	)
 	.await;
@@ -190,6 +200,7 @@ async fn get_a_bridge_ip(
 	bridge_flag_arguments: (Option<Ipv4Addr>, Option<String>, Option<String>),
 	bridge_or_params_argument: Option<String>,
 	had_params_arg: bool,
+	find_by_args: (Duration, u16),
 	host_state_path: Option<PathBuf>,
 ) -> Ipv4Addr {
 	if let Some((filter_ip, filter_mac, filter_name)) = coalesce_bridge_arguments(
@@ -203,7 +214,7 @@ async fn get_a_bridge_ip(
 			if let Some(ip_address) = *BRIDGE_CURRENT_IP_ADDRESS {
 				return ip_address;
 			} else if let Some(name) = BRIDGE_CURRENT_NAME.as_deref() {
-				return get_mochiato_bridge_ip(use_json, name).await;
+				return get_mochiato_bridge_ip(use_json, name, find_by_args).await;
 			} else if use_json {
 				error!(
 					id = "bridgectl::set_parameters::no_bridge_filters",
@@ -233,7 +244,8 @@ async fn get_a_bridge_ip(
 				MIONFindBy::Name(filter_name.clone().unwrap_or_default())
 			},
 			false,
-			None,
+			Some(find_by_args.0),
+			Some(find_by_args.1),
 		)
 		.await
 		{
@@ -294,12 +306,23 @@ async fn get_a_bridge_ip(
 			}
 		}
 	} else {
-		get_default_bridge_ip(use_json, host_state_path).await
+		get_default_bridge_ip(use_json, host_state_path, find_by_args).await
 	}
 }
 
-async fn get_mochiato_bridge_ip(use_json: bool, bridge_name: &str) -> Ipv4Addr {
-	match find_mion(MIONFindBy::Name(bridge_name.to_owned()), false, None).await {
+async fn get_mochiato_bridge_ip(
+	use_json: bool,
+	bridge_name: &str,
+	find_by_args: (Duration, u16),
+) -> Ipv4Addr {
+	match find_mion(
+		MIONFindBy::Name(bridge_name.to_owned()),
+		false,
+		Some(find_by_args.0),
+		Some(find_by_args.1),
+	)
+	.await
+	{
 		Ok(Some(identity)) => identity.ip_address(),
 		Ok(None) => {
 			if use_json {
@@ -353,12 +376,23 @@ async fn get_mochiato_bridge_ip(use_json: bool, bridge_name: &str) -> Ipv4Addr {
 	}
 }
 
-async fn get_default_bridge_ip(use_json: bool, host_state_path: Option<PathBuf>) -> Ipv4Addr {
+async fn get_default_bridge_ip(
+	use_json: bool,
+	host_state_path: Option<PathBuf>,
+	find_by_args: (Duration, u16),
+) -> Ipv4Addr {
 	let (default_bridge_name, opt_ip) = get_default_bridge(use_json, host_state_path.clone()).await;
 	if let Some(ip) = opt_ip {
 		ip
 	} else {
-		match find_mion(MIONFindBy::Name(default_bridge_name.clone()), false, None).await {
+		match find_mion(
+			MIONFindBy::Name(default_bridge_name.clone()),
+			false,
+			Some(find_by_args.0),
+			Some(find_by_args.1),
+		)
+		.await
+		{
 			Ok(Some(identity)) => identity.ip_address(),
 			Ok(None) => {
 				if use_json {

--- a/cmd/bridgectl/src/exit_codes.rs
+++ b/cmd/bridgectl/src/exit_codes.rs
@@ -1,5 +1,6 @@
 //! Just a list of all the exit codes in our process.
 
+pub const NOT_YET_IMPLEMENTED: i32 = -1;
 pub const LOGGING_HANDLER_INSTALL_FAILURE: i32 = 1;
 pub const ARGUMENT_PARSING_FAILURE: i32 = 2;
 pub const NO_ARGUMENT_SPECIFIED_FAILURE: i32 = 3;
@@ -40,3 +41,6 @@ pub const GET_NO_BRIDGE_FILTERS: i32 = 37;
 pub const GET_PARAMS_NO_BRIDGE_FILTERS: i32 = 38;
 pub const SET_PARAMS_NO_BRIDGE_FILTERS: i32 = 39;
 pub const DUMP_PARAMS_NO_BRIDGE_FILTERS: i32 = 40;
+pub const BOOT_NO_BRIDGE_FILTERS: i32 = 41;
+pub const BOOT_NO_AVAILABLE_BRIDGE: i32 = 42;
+pub const BOOT_CGI_FAILURE: i32 = 43;

--- a/cmd/bridgectl/src/knobs/cli.rs
+++ b/cmd/bridgectl/src/knobs/cli.rs
@@ -87,6 +87,49 @@ pub enum Subcommands {
 		)]
 		set_default: bool,
 	},
+	#[command(name = "boot", visible_alias = "power-on")]
+	Boot {
+		#[arg(
+			short = 'd',
+			long = "default",
+			help = "Set the parameters on the default bridge.",
+			long_help = "A shortcut to set parameters on the default bridge, not needing to specify any other lookup fields."
+		)]
+		default: bool,
+		#[arg(
+			short = 'i',
+			long = "ip",
+			help = "The IP of the bridge to set the parameters on.",
+			long_help = "Set the parameters of the bridge located at this IP address."
+		)]
+		bridge_ipaddr: Option<Ipv4Addr>,
+		#[arg(
+			short = 'm',
+			long = "mac-address",
+			help = "The Mac Address of the bridge to set the parameters on.",
+			long_help = "Set the parameters of the bridge found by searching for the bridge with this MAC Address."
+		)]
+		bridge_mac: Option<String>,
+		#[arg(
+			short = 'n',
+			long = "name",
+			help = "The Name of the bridge to set the parameters on.",
+			long_help = "Set the parameters of the bridge found by searching for the bridge with this Name."
+		)]
+		bridge_name: Option<String>,
+		#[arg(
+			index = 1,
+			help = "Search for a bridge with a particular name/ip/mac address.",
+			long_help = "If you don't want to specify what bridge you want to set parameters on with `--ip`, `--mac-address`, or `--name` you can just pass in a positional argument where we can guess how to find the bridge."
+		)]
+		bridge_name_positional: Option<String>,
+		#[arg(
+			long = "boot-without-pcfs",
+			help = "Just boot the device without PCFS",
+			long_help = "Disable almost all other options, and just boot the device without any connection to the PC."
+		)]
+		without_pcfs: bool,
+	},
 	#[command(name = "dump-parameters", visible_alias = "dp")]
 	DumpParameters {
 		#[arg(
@@ -375,6 +418,14 @@ impl Subcommands {
 				use_cache,
 				output_as_table,
 			} => name == "list" || name == "ls",
+			Self::Boot {
+				default,
+				bridge_ipaddr,
+				bridge_mac,
+				bridge_name,
+				bridge_name_positional,
+				without_pcfs,
+			} => name == "boot" || name == "power-on",
 			Self::Remove {
 				bridge_name,
 				bridge_name_positional,

--- a/cmd/bridgectl/src/knobs/cli.rs
+++ b/cmd/bridgectl/src/knobs/cli.rs
@@ -14,6 +14,13 @@ pub struct CliArguments {
 		long_help = "The path to the `bridge_env.ini` file to use if it's not in the default location."
 	)]
 	pub bridge_state_path: Option<PathBuf>,
+	#[arg(
+		global = true,
+		long = "bridge-control-port-override",
+		help = "A way to override the control port which should never be needed.",
+		long_help = "Allow overriding the scanning port aka CONTROL port for finding cat-dev bridges."
+	)]
+	pub control_port_override: Option<u16>,
 	#[command(subcommand)]
 	pub commands: Option<Subcommands>,
 	#[arg(
@@ -32,6 +39,13 @@ pub struct CliArguments {
 		long_help = "Switch all logging and output to JSON for machine parsable output. NOTE: there is no necissarily guaranteed structure, though we will not break it unnecissarily."
 	)]
 	pub json: bool,
+	#[arg(
+		global = true,
+		long = "scan-early-timeout-seconds",
+		help = "The amount of seconds to wait before bailing early when scanning for a bridge (by default this is 3).",
+		long_help = "CAT-DEV's MUST respond to broadcasts within 10 seconds, but in reality most folks only have one cat-dev / non busy networks were they will respond faster, in this case it's generally better to exit early. How early we decide to exit is controlled by this variable."
+	)]
+	pub scan_timeout: Option<u64>,
 }
 
 #[derive(Parser, Debug)]
@@ -226,13 +240,6 @@ pub enum Subcommands {
 		)]
 		use_cache: bool,
 		#[arg(
-			short = 'e',
-			long = "early-timeout-seconds",
-			help = "The amount of seconds to wait before bailing early (by default this is 3).",
-			long_help = "CAT-DEV's MUST respond to broadcasts within 10 seconds, but in reality most folks only have one cat-dev / non busy networks were they will respond faster, in this case it's generally better to exit early. How early we decide to exit is controlled by this variable."
-		)]
-		scan_timeout: Option<u64>,
-		#[arg(
 			short = 't',
 			long = "table-output",
 			help = "Output the list of bridges as a particular table.",
@@ -366,7 +373,6 @@ impl Subcommands {
 			Self::Help {} => name == "help",
 			Self::List {
 				use_cache,
-				scan_timeout,
 				output_as_table,
 			} => name == "list" || name == "ls",
 			Self::Remove {

--- a/cmd/bridgectl/src/knobs/env.rs
+++ b/cmd/bridgectl/src/knobs/env.rs
@@ -5,6 +5,7 @@ use std::{
 	env::{var as env_var, var_os as env_var_os},
 	net::Ipv4Addr,
 	path::PathBuf,
+	time::Duration,
 };
 use tracing::warn;
 
@@ -46,6 +47,47 @@ pub static BRIDGE_CURRENT_IP_ADDRESS: Lazy<Option<Ipv4Addr>> = Lazy::new(|| {
 			Ok(val) => Some(val),
 			Err(cause) => {
 				warn!(?cause, "Not Honoring `cafe`/`cafex`/`mochiato` set environment variable of `BRIDGE_CURRENT_IP_ADDRESS`, not a valid IPv4 address.");
+				None
+			}
+		}
+	})
+});
+
+/// A way of configuring the scan timeout rather than needing to manually
+/// specify over the CLI. This value is specifically in seconds.
+///
+/// Environment Variable Name: `BRIDGE_SCAN_TIMEOUT_SECONDS`
+/// Expected Values: Empty, or a number of seconds.
+/// Type: [`u64`]
+pub static BRIDGE_SCAN_TIMEOUT: Lazy<Option<Duration>> = Lazy::new(|| {
+	env_var("BRIDGE_SCAN_TIMEOUT_SECONDS").ok().and_then(|val| {
+		match val.parse::<u64>() {
+			Ok(val) => Some(Duration::from_secs(val)),
+			Err(cause) => {
+				warn!(?cause, "Not honoring environment variable `BRIDGE_SCAN_TIMEOUT_SECONDS`, not a valid number.");
+				None
+			}
+		}
+	})
+});
+
+/// A way of configuring the port to reach out to a control port.
+///
+/// *note: we believe this port will ALWAYS be 7974, however, due to what we
+/// believe is a buggy case there are some cases where official tools can
+/// reach out to separate ports. AGAIN WE BELIEVE THIS IS A BUG, AND THUS YOU
+/// SHOULD NEVER NEED TO CHANGE THIS. IF YOU DO, PLEASE CONTACT US SO WE CAN
+/// DIG IN.*
+///
+/// Environment Variable Name: `BRIDGE_CONTROL_PORT_OVERRIDE`
+/// Expected Values: Empty, or a port number (0-65536).
+/// Type: [`u16`]
+pub static BRIDGE_CONTROL_PORT: Lazy<Option<u16>> = Lazy::new(|| {
+	env_var("BRIDGE_CONTROL_PORT_OVERRIDE").ok().and_then(|val| {
+		match val.parse::<u16>() {
+			Ok(val) => Some(val),
+			Err(cause) => {
+				warn!(?cause, "Not honoring environment variable `BRIDGE_CONTROL_PORT_OVERRIDE`, not a valid port number.");
 				None
 			}
 		}

--- a/cmd/bridgectl/src/knobs/mod.rs
+++ b/cmd/bridgectl/src/knobs/mod.rs
@@ -5,3 +5,30 @@
 
 pub mod cli;
 pub mod env;
+
+use crate::knobs::{
+	cli::CliArguments,
+	env::{BRIDGE_CONTROL_PORT, BRIDGE_SCAN_TIMEOUT},
+};
+use cat_dev::mion::proto::DEFAULT_MION_CONTROL_PORT;
+use std::time::Duration;
+
+/// Get the configured scan timeout for finding bridges.
+#[must_use]
+pub fn get_scan_timeout(args: &CliArguments) -> Duration {
+	let mut returned_timeout = args.scan_timeout.map(Duration::from_secs);
+	if returned_timeout.is_none() {
+		returned_timeout = *BRIDGE_SCAN_TIMEOUT;
+	}
+	returned_timeout.unwrap_or(Duration::from_secs(3))
+}
+
+/// Get the control port to use for scanning requests.
+#[must_use]
+pub fn get_control_port(args: &CliArguments) -> u16 {
+	let mut returned_port = args.control_port_override;
+	if returned_port.is_none() {
+		returned_port = *BRIDGE_CONTROL_PORT;
+	}
+	returned_port.unwrap_or(DEFAULT_MION_CONTROL_PORT)
+}

--- a/cmd/bridgectl/src/main.rs
+++ b/cmd/bridgectl/src/main.rs
@@ -25,6 +25,7 @@ use crate::{
 	knobs::{
 		cli::{CliArguments, Subcommands},
 		env::USE_JSON_OUTPUT,
+		get_control_port, get_scan_timeout,
 	},
 	utils::get_bridge_state_path,
 };
@@ -50,6 +51,8 @@ async fn main() {
 			0
 		});
 	}
+	let scan_timeout = get_scan_timeout(&argv);
+	let control_port = get_control_port(&argv);
 
 	let Some(sub_command) = argv.commands else {
 		if use_json {
@@ -78,6 +81,7 @@ async fn main() {
 				use_json,
 				(bridge_name, bridge_ipaddr),
 				(bridge_name_positional, bridge_ip_positional),
+				(scan_timeout, control_port),
 				get_bridge_state_path(&argv.bridge_state_path, use_json),
 				set_default,
 			)
@@ -96,25 +100,8 @@ async fn main() {
 				default,
 				(bridge_ipaddr, bridge_mac, bridge_name),
 				bridge_name_positional,
+				(scan_timeout, control_port),
 				parameter_space_port,
-				argv.bridge_state_path,
-			)
-			.await;
-		}
-		Subcommands::Get {
-			default,
-			bridge_ipaddr,
-			bridge_mac,
-			bridge_name,
-			bridge_name_positional,
-			output_as_table,
-		} => {
-			handle_get(
-				use_json,
-				output_as_table,
-				default,
-				(bridge_ipaddr, bridge_mac, bridge_name),
-				bridge_name_positional,
 				argv.bridge_state_path,
 			)
 			.await;
@@ -134,7 +121,27 @@ async fn main() {
 				(bridge_ipaddr, bridge_mac, bridge_name),
 				bridge_name_positional,
 				parameter_names_positional,
+				(scan_timeout, control_port),
 				parameter_space_port,
+				argv.bridge_state_path,
+			)
+			.await;
+		}
+		Subcommands::Get {
+			default,
+			bridge_ipaddr,
+			bridge_mac,
+			bridge_name,
+			bridge_name_positional,
+			output_as_table,
+		} => {
+			handle_get(
+				use_json,
+				output_as_table,
+				default,
+				(bridge_ipaddr, bridge_mac, bridge_name),
+				bridge_name_positional,
+				(scan_timeout, control_port),
 				argv.bridge_state_path,
 			)
 			.await;
@@ -143,14 +150,13 @@ async fn main() {
 		Subcommands::Help {} => unreachable!(),
 		Subcommands::List {
 			use_cache,
-			scan_timeout,
 			output_as_table,
 		} => {
 			handle_list(
 				use_json,
 				use_cache,
 				output_as_table,
-				scan_timeout,
+				(scan_timeout, control_port),
 				argv.bridge_state_path,
 			)
 			.await;
@@ -194,6 +200,7 @@ async fn main() {
 				(bridge_ipaddr, bridge_mac, bridge_name),
 				bridge_name_positional,
 				parameter_names_positional,
+				(scan_timeout, control_port),
 				parameter_space_port,
 				argv.bridge_state_path,
 			)

--- a/cmd/bridgectl/src/main.rs
+++ b/cmd/bridgectl/src/main.rs
@@ -14,9 +14,9 @@ pub mod utils;
 
 use crate::{
 	commands::{
-		handle_add_or_update, handle_dump_parameters, handle_get, handle_get_parameters,
-		handle_help, handle_list, handle_remove_bridge, handle_set_default_bridge,
-		handle_set_parameters,
+		handle_add_or_update, handle_boot, handle_dump_parameters, handle_get,
+		handle_get_parameters, handle_help, handle_list, handle_remove_bridge,
+		handle_set_default_bridge, handle_set_parameters,
 	},
 	exit_codes::{
 		ARGUMENT_PARSING_FAILURE, LOGGING_HANDLER_INSTALL_FAILURE, NO_ARGUMENT_SPECIFIED_FAILURE,
@@ -84,6 +84,25 @@ async fn main() {
 				(scan_timeout, control_port),
 				get_bridge_state_path(&argv.bridge_state_path, use_json),
 				set_default,
+			)
+			.await;
+		}
+		Subcommands::Boot {
+			default,
+			bridge_ipaddr,
+			bridge_mac,
+			bridge_name,
+			bridge_name_positional,
+			without_pcfs,
+		} => {
+			handle_boot(
+				use_json,
+				default,
+				(bridge_ipaddr, bridge_mac, bridge_name),
+				bridge_name_positional,
+				(scan_timeout, control_port),
+				argv.bridge_state_path,
+				without_pcfs,
 			)
 			.await;
 		}

--- a/cmd/findbridge/README.md
+++ b/cmd/findbridge/README.md
@@ -64,7 +64,9 @@ Some kernels can automatically forward packets, other times you might be able
 to use a tool like: <https://github.com/udp-redux/udp-broadcast-relay-redux>
 to relay between the two. If you were using udp-broadcast-relay-redux you'd
 ensure your pc connected to both networks is running the following two
-commands:
+commands (note: you may need to add more/change the port being used if you are
+not using a standard setup, some things may try to use the ATAPI configured
+port, which is also by default 7974, but can be changed):
 
 ```sh
 ./udp-broadcast-relay-redux --id 1 --port 7974 --dev <network-one-interface> --dev <network-two-interface>

--- a/cmd/findbridge/src/main.rs
+++ b/cmd/findbridge/src/main.rs
@@ -94,6 +94,7 @@ async fn find_one(find_arg: String, opts: &CliOpts) -> bool {
 			opts.detail
 		},
 		Some(Duration::from_secs(3)),
+		None,
 		create_interface_logging_hook(opts.verbose),
 	)
 	.await
@@ -125,6 +126,7 @@ async fn find_one(find_arg: String, opts: &CliOpts) -> bool {
 async fn scan_all(opts: &CliOpts) {
 	let Ok(mut recv_channel) = discover_bridges_with_logging_hooks(
 		opts.detail,
+		None,
 		create_interface_logging_hook(opts.verbose),
 	)
 	.await

--- a/installer-scripts/osx/distribution.xml
+++ b/installer-scripts/osx/distribution.xml
@@ -12,5 +12,5 @@
   <choice id="sprig" title="sprig">
     <pkg-ref id="sprig.pkg"/>
   </choice>
-  <pkg-ref id="sprig.pkg" version="0.0.3" />
+  <pkg-ref id="sprig.pkg" version="0.0.4" />
 </installer-gui-script>

--- a/installer-scripts/osx/package.sh
+++ b/installer-scripts/osx/package.sh
@@ -15,5 +15,5 @@ cp ../../../cmd/getbridge/sh/getbridge ./
 cp ../../../cmd/getbridgetype/sh/getbridgetype ./
 cp ../../../cmd/setbridge/sh/setbridge ./
 cd ../
-pkgbuild --root ./working-dir/ --identifier "dev.rem-verse.sprig" --version "0.0.3" --install-location "/usr/local/bin" sprig.pkg
+pkgbuild --root ./working-dir/ --identifier "dev.rem-verse.sprig" --version "0.0.4" --install-location "/usr/local/bin" sprig.pkg
 productbuild --synthesize --package "sprig.pkg" sprig.dist

--- a/installer-scripts/unix/nfpm.yaml
+++ b/installer-scripts/unix/nfpm.yaml
@@ -6,7 +6,7 @@ homepage: "https://github.com/rem-verse/sprig"
 license: "MIT"
 maintainer: "Cynthia <cynthia@corp.rem-verse.email>"
 vendor: "RemVerse"
-version: "v0.0.3"
+version: "v0.0.4"
 
 arch: "amd64"
 platform: "linux"

--- a/installer-scripts/win/sprig.wxs
+++ b/installer-scripts/win/sprig.wxs
@@ -6,7 +6,7 @@
   <Package Manufacturer="RemVerse"
     Name="Sprig"
     Language="1033"
-    Version="0.0.3"
+    Version="0.0.4"
     UpgradeCode="f25b6ffc-5890-42f2-a1c1-0f7dd4a9ee11">
 
     <ui:WixUI Id="WixUI_Minimal" InstallDirectory="INSTALLFOLDER" />

--- a/pkg/cat-dev/Cargo.toml
+++ b/pkg/cat-dev/Cargo.toml
@@ -18,7 +18,7 @@ local-ip-address = "^0.5.7"
 mac_address.workspace = true
 miette.workspace = true
 network-interface.workspace = true
-serde = "^1.0.196"
+serde = "^1.0.197"
 serde_urlencoded = "^0.7.1"
 thiserror = "^1.0.57"
 tracing.workspace = true
@@ -27,4 +27,4 @@ valuable.workspace = true
 
 [dev-dependencies]
 once_cell.workspace = true
-tempfile = "^3.10.0"
+tempfile = "^3.10.1"

--- a/pkg/cat-dev/README.md
+++ b/pkg/cat-dev/README.md
@@ -64,9 +64,10 @@ use cat_dev::mion::discovery::discover_bridges;
 /// These all return options that will only be populated if
 /// `fetch_detailed_fields` is marked as true.
 async fn stream_bridges(fetch_detailed_fields: bool) {
-  let mut channel_to_stream_bridges = discover_bridges(fetch_detailed_fields)
-    .await
-    .expect("Failed to discover bridges!");
+  let mut channel_to_stream_bridges = discover_bridges(
+    fetch_detailed_fields,
+    None,
+  ).await.expect("Failed to discover bridges!");
 
   // This will block for a potentially "long-ish" (like 10 seconds) time.
   //
@@ -104,6 +105,7 @@ async fn find_a_mion_by_name(
     // wanna wait the full 10 seconds you can specify an optional early
     // timeout.
     early_search_timeout,
+    None,
   ).await.expect("could not conduct a search for a mion.") {
     println!("Found bridge: {bridge}");
   } else {

--- a/pkg/cat-dev/src/mion/cgis/control.rs
+++ b/pkg/cat-dev/src/mion/cgis/control.rs
@@ -3,7 +3,10 @@
 
 use crate::{
 	errors::{CatBridgeError, NetworkError, NetworkParseError},
-	mion::{cgis::AUTHZ_HEADER, proto::cgis::ControlOperation},
+	mion::{
+		cgis::AUTHZ_HEADER,
+		proto::cgis::{ControlOperation, SetParameter},
+	},
 };
 use fnv::FnvHashMap;
 use hyper::{
@@ -14,7 +17,7 @@ use hyper::{
 use local_ip_address::local_ip;
 use serde::Serialize;
 use std::net::Ipv4Addr;
-use tracing::warn;
+use tracing::{field::valuable, warn};
 
 /// Perform a `get_info` request given a host, and a name.
 ///
@@ -83,7 +86,124 @@ where
 		.map_err(NetworkParseError::InvalidDataNeedsUTF8)
 		.map_err(NetworkError::ParseError)?;
 
-	extract_body_tags(&body_as_string)
+	extract_body_tags(&body_as_string, ControlOperation::GetInfo.into())
+}
+
+/// Perform a `set_param` request given a host, and the parameter to set.
+///
+/// ## Errors
+///
+/// - If we cannot encode the parameters as a form url encoded.
+/// - If we cannot make the HTTP request.
+/// - If the server does not respond with a 200.
+/// - If we cannot read the body from HTTP.
+/// - If we cannot parse the HTML response.
+pub async fn set_param(
+	mion_ip: Ipv4Addr,
+	parameter_to_set: SetParameter,
+) -> Result<bool, CatBridgeError> {
+	set_param_with_raw_client(&Client::default(), mion_ip, parameter_to_set).await
+}
+
+/// Set a parameter on the MION, but with an already existing HTTP Client.
+///
+/// ## Errors
+///
+/// - If we cannot encode the parameters as a form url encoded.
+/// - If we cannot make the HTTP request.
+/// - If the server does not respond with a 200.
+/// - If we cannot read the body from HTTP.
+/// - If we cannot parse the HTML response.
+pub async fn set_param_with_raw_client<ClientConnectorTy>(
+	client: &Client<ClientConnectorTy>,
+	mion_ip: Ipv4Addr,
+	parameter_to_set: SetParameter,
+) -> Result<bool, CatBridgeError>
+where
+	ClientConnectorTy: Clone + Connect + Send + Sync + 'static,
+{
+	let response = do_raw_control_request(
+		client,
+		mion_ip,
+		&[
+			(
+				"operation".to_owned(),
+				Into::<&str>::into(ControlOperation::SetParam).to_owned(),
+			),
+			(
+				format!("{parameter_to_set}"),
+				parameter_to_set.get_value_as_string(),
+			),
+		],
+	)
+	.await?;
+	let status = response.status().as_u16();
+	let body_result = read_http_body_bytes(response.into_body())
+		.await
+		.map_err(NetworkError::HyperError);
+	if status != 200 {
+		if let Ok(body) = body_result {
+			return Err(CatBridgeError::NetworkError(NetworkError::ParseError(
+				NetworkParseError::UnexpectedStatusCode(status, body),
+			)));
+		}
+
+		return Err(CatBridgeError::NetworkError(NetworkError::ParseError(
+			NetworkParseError::UnexpectedStatusCodeNoBody(status),
+		)));
+	}
+	let read_body_bytes = body_result?;
+	let body_as_string = String::from_utf8(read_body_bytes.into())
+		.map_err(NetworkParseError::InvalidDataNeedsUTF8)
+		.map_err(NetworkError::ParseError)?;
+
+	parse_result_from_body(
+		&body_as_string,
+		Into::<&str>::into(ControlOperation::SetParam),
+	)
+}
+
+#[doc(hidden)]
+pub async fn very_hacky_will_break_dont_use_power_on(
+	mion_ip: Ipv4Addr,
+) -> Result<bool, CatBridgeError> {
+	let response = do_raw_control_request(
+		&Client::default(),
+		mion_ip,
+		&[
+			("operation", Into::<&str>::into(ControlOperation::PowerOnV2)),
+			("emulation", "off"),
+			(
+				"host",
+				&format!("{}", local_ip().map_err(NetworkError::LocalIpError)?),
+			),
+		],
+	)
+	.await?;
+	let status = response.status().as_u16();
+	let body_result = read_http_body_bytes(response.into_body())
+		.await
+		.map_err(NetworkError::HyperError);
+	if status != 200 {
+		if let Ok(body) = body_result {
+			return Err(CatBridgeError::NetworkError(NetworkError::ParseError(
+				NetworkParseError::UnexpectedStatusCode(status, body),
+			)));
+		}
+
+		return Err(CatBridgeError::NetworkError(NetworkError::ParseError(
+			NetworkParseError::UnexpectedStatusCodeNoBody(status),
+		)));
+	}
+	let read_body_bytes = body_result?;
+	let body_as_string = String::from_utf8(read_body_bytes.into())
+		.map_err(NetworkParseError::InvalidDataNeedsUTF8)
+		.map_err(NetworkError::ParseError)?;
+
+	parse_result_from_body(
+		&body_as_string,
+		Into::<&str>::into(ControlOperation::SetParam),
+	)
 }
 
 /// Perform a raw operation on the MION board's `control.cgi` page.
@@ -132,7 +252,10 @@ where
 ///
 /// - If we cannot find the start `<body>` tag.
 /// - If we cannot find the end `</body>` tag.
-fn extract_body_tags(body: &str) -> Result<FnvHashMap<String, String>, CatBridgeError> {
+fn extract_body_tags(
+	body: &str,
+	operation_name: &str,
+) -> Result<FnvHashMap<String, String>, CatBridgeError> {
 	let start_tag_location = body.find("<body>").map(|num| num + 6).ok_or_else(|| {
 		CatBridgeError::NetworkError(NetworkError::ParseError(
 			NetworkParseError::HtmlResponseMissingBody(body.to_owned()),
@@ -162,11 +285,69 @@ fn extract_body_tags(body: &str) -> Result<FnvHashMap<String, String>, CatBridge
 				let (key, value) = line.split_at(location);
 				Some((key.to_owned(), value.trim_start_matches(':').to_owned()))
 			} else {
-				warn!("Unparsable line from body on control.cgi: {line}");
+				warn!(%operation_name, "Unparsable line from body on mion/control.cgi: {line}");
 				None
 			}
 		})
 		.collect::<FnvHashMap<String, String>>();
 
 	Ok(fields)
+}
+
+fn parse_result_from_body(body: &str, operation_name: &str) -> Result<bool, CatBridgeError> {
+	let start_tag_location = body.find("<body>").map(|num| num + 6).ok_or_else(|| {
+		CatBridgeError::NetworkError(NetworkError::ParseError(
+			NetworkParseError::HtmlResponseMissingBody(body.to_owned()),
+		))
+	})?;
+	let body_without_start_tag = body.split_at(start_tag_location).1;
+	let end_tag_location = body_without_start_tag.find("</body>").ok_or_else(|| {
+		CatBridgeError::NetworkError(NetworkError::ParseError(
+			NetworkParseError::HtmlResponseMissingBody(body.to_owned()),
+		))
+	})?;
+	let just_inner_body = body_without_start_tag.split_at(end_tag_location).0;
+	let without_newlines = just_inner_body.replace('\n', "");
+
+	let mut was_successful = false;
+	let mut returned_result_code = "";
+	let mut log_lines = Vec::with_capacity(0);
+	let mut extra_lines = Vec::with_capacity(0);
+	for line in without_newlines
+		.split("<br>")
+		.fold(Vec::new(), |mut accum, item| {
+			accum.extend(item.split("<br/>"));
+			accum
+		}) {
+		let trimmed_line = line.trim();
+		if trimmed_line.is_empty() {
+			continue;
+		}
+
+		if let Some(result_code) = trimmed_line.strip_prefix("RESULT:") {
+			returned_result_code = result_code;
+			if result_code == "OK" {
+				was_successful = true;
+			}
+		} else if trimmed_line.starts_with("INFO:")
+			|| trimmed_line.starts_with("ERROR:")
+			|| trimmed_line.starts_with("WARN:")
+		{
+			log_lines.push(trimmed_line);
+		} else {
+			extra_lines.push(trimmed_line);
+		}
+	}
+
+	if !was_successful {
+		warn!(
+			log_lines = valuable(&log_lines),
+			extra_lines = valuable(&extra_lines),
+			%operation_name,
+			result_code = %returned_result_code,
+			"got an error back from mion/control.cgi",
+		);
+	}
+
+	Ok(was_successful)
 }

--- a/pkg/cat-dev/src/mion/cgis/control.rs
+++ b/pkg/cat-dev/src/mion/cgis/control.rs
@@ -3,7 +3,7 @@
 
 use crate::{
 	errors::{CatBridgeError, NetworkError, NetworkParseError},
-	mion::proto::cgis::ControlOperation,
+	mion::{cgis::AUTHZ_HEADER, proto::cgis::ControlOperation},
 };
 use fnv::FnvHashMap;
 use hyper::{
@@ -15,18 +15,6 @@ use local_ip_address::local_ip;
 use serde::Serialize;
 use std::net::Ipv4Addr;
 use tracing::warn;
-
-/// HTTP Basic authorization header.
-///
-/// This gets passed as the header:
-/// `Authorization: Basic bWlvbjovTXVsdGlfSS9PX05ldHdvcmsv`
-///
-/// Given this is http basic auth, you can decode this string as:
-/// `mion:/Multi_I/O_Network/`
-///
-/// Which means the username is: `mion`, and the password is:
-/// `/Multi_I/O_Network/`.
-const AUTHZ_HEADER: &str = "bWlvbjovTXVsdGlfSS9PX05ldHdvcmsv";
 
 /// Perform a `get_info` request given a host, and a name.
 ///

--- a/pkg/cat-dev/src/mion/cgis/mod.rs
+++ b/pkg/cat-dev/src/mion/cgis/mod.rs
@@ -1,0 +1,21 @@
+//! CGI's that are available to interact with the MION on.
+//!
+//! These various CGI web pages you can interact with normally on the web.
+
+/// HTTP Basic authorization header.
+///
+/// This gets passed as the header:
+/// `Authorization: Basic bWlvbjovTXVsdGlfSS9PX05ldHdvcmsv`
+///
+/// Given this is http basic auth, you can decode this string as:
+/// `mion:/Multi_I/O_Network/`
+///
+/// Which means the username is: `mion`, and the password is:
+/// `/Multi_I/O_Network/`.
+const AUTHZ_HEADER: &str = "bWlvbjovTXVsdGlfSS9PX05ldHdvcmsv";
+
+mod control;
+mod signal_get;
+
+pub use control::*;
+pub use signal_get::*;

--- a/pkg/cat-dev/src/mion/cgis/signal_get.rs
+++ b/pkg/cat-dev/src/mion/cgis/signal_get.rs
@@ -1,0 +1,123 @@
+//! API's for interacting with `/signal_get.cgi`, an HTTP interface for
+//! getting signals
+
+use crate::{
+	errors::{CatBridgeError, NetworkError, NetworkParseError},
+	mion::cgis::AUTHZ_HEADER,
+};
+use hyper::{
+	body::to_bytes as read_http_body_bytes,
+	client::{connect::Connect, Client},
+	Body, Request, Response, Version,
+};
+use serde::Serialize;
+use std::net::Ipv4Addr;
+
+/// Perform a `signal_get` request for the `VDD2` signal given a host.
+///
+/// ## Errors
+///
+/// - If we cannot encode the parameters as a form url encoded.
+/// - If we cannot make the HTTP request.
+/// - If the server does not respond with a 200.
+/// - If we cannot read the body from HTTP.
+/// - If we cannot parse the HTML response.
+pub async fn get_vdd2(mion_ip: Ipv4Addr) -> Result<String, CatBridgeError> {
+	get_vdd2_with_raw_client(&Client::default(), mion_ip).await
+}
+
+/// Perform a get info request, but with an already existing HTTP client.
+///
+/// ## Errors
+///
+/// - If we cannot encode the parameters as a form url encoded.
+/// - If we cannot make the HTTP request.
+/// - If the server does not respond with a 200.
+/// - If we cannot read the body from HTTP.
+/// - If we cannot parse the HTML response.
+pub async fn get_vdd2_with_raw_client<ClientConnectorTy>(
+	client: &Client<ClientConnectorTy>,
+	mion_ip: Ipv4Addr,
+) -> Result<String, CatBridgeError>
+where
+	ClientConnectorTy: Clone + Connect + Send + Sync + 'static,
+{
+	let response = do_raw_signal_http_request(client, mion_ip, &[("sig", "VDD2")]).await?;
+	let status = response.status().as_u16();
+	let body_result = read_http_body_bytes(response.into_body())
+		.await
+		.map_err(NetworkError::HyperError);
+	if status != 200 {
+		if let Ok(body) = body_result {
+			return Err(CatBridgeError::NetworkError(NetworkError::ParseError(
+				NetworkParseError::UnexpectedStatusCode(status, body),
+			)));
+		}
+
+		return Err(CatBridgeError::NetworkError(NetworkError::ParseError(
+			NetworkParseError::UnexpectedStatusCodeNoBody(status),
+		)));
+	}
+	let read_body_bytes = body_result?;
+	let body_as_string = String::from_utf8(read_body_bytes.into())
+		.map_err(NetworkParseError::InvalidDataNeedsUTF8)
+		.map_err(NetworkError::ParseError)?;
+
+	let start_tag_location = body_as_string
+		.find("<body>")
+		.map(|num| num + 6)
+		.ok_or_else(|| {
+			CatBridgeError::NetworkError(NetworkError::ParseError(
+				NetworkParseError::HtmlResponseMissingBody(body_as_string.clone()),
+			))
+		})?;
+	let body_without_start_tag = body_as_string.split_at(start_tag_location).1;
+	let end_tag_location = body_without_start_tag.find("</body>").ok_or_else(|| {
+		CatBridgeError::NetworkError(NetworkError::ParseError(
+			NetworkParseError::HtmlResponseMissingBody(body_as_string.clone()),
+		))
+	})?;
+
+	Ok(body_without_start_tag
+		.split_at(end_tag_location)
+		.0
+		.to_owned())
+}
+
+/// Perform a raw operation on the MION board's `control.cgi` page.
+///
+/// *note: you probably want to call one of the actual methods, as this is
+/// basically just a thin wrapper around an HTTP Post Request. Not doing much
+/// else more. A lot of it requires that you set things up correctly.*
+///
+/// ## Errors
+///
+/// - If we cannot make an HTTP request to the MION Request.
+/// - If we fail to encode your parameters into a request body.
+pub async fn do_raw_signal_http_request<'key, 'value, ClientConnectorTy, UrlEncodableType>(
+	client: &Client<ClientConnectorTy>,
+	mion_ip: Ipv4Addr,
+	url_parameters: UrlEncodableType,
+) -> Result<Response<Body>, NetworkError>
+where
+	ClientConnectorTy: Clone + Connect + Send + Sync + 'static,
+	UrlEncodableType: Serialize,
+{
+	Ok(client
+		.request(
+			Request::post(format!("http://{mion_ip}/signal_get.cgi"))
+				.version(Version::HTTP_11)
+				.header("authorization", format!("Basic {AUTHZ_HEADER}"))
+				.header("content-type", "application/x-www-form-urlencoded")
+				.header(
+					"user-agent",
+					format!("cat-dev/{}", env!("CARGO_PKG_VERSION")),
+				)
+				.body(
+					serde_urlencoded::to_string(&url_parameters)
+						.map_err(NetworkParseError::FormDataEncodeError)?
+						.into(),
+				)?,
+		)
+		.await?)
+}

--- a/pkg/cat-dev/src/mion/mod.rs
+++ b/pkg/cat-dev/src/mion/mod.rs
@@ -7,7 +7,7 @@
 //! In general if you're trying to look for things relating to the bridge as a
 //! whole, you're _probably_ really actually talking to the MION.
 
-pub mod control;
+pub mod cgis;
 pub mod discovery;
 pub mod parameter;
 pub mod proto;

--- a/pkg/cat-dev/src/mion/proto/cgis/control.rs
+++ b/pkg/cat-dev/src/mion/proto/cgis/control.rs
@@ -47,6 +47,42 @@ impl TryFrom<&str> for ControlOperation {
 	}
 }
 
+/// The type of parameters you can set on the control page.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum SetParameter {
+	/// Set the ATAPI Port to use.
+	AtapiPort(u16),
+}
+
+impl SetParameter {
+	/// Get the value regardless of what it is as a string.
+	#[must_use]
+	pub fn get_value_as_string(&self) -> String {
+		match self {
+			Self::AtapiPort(ref port) => format!("{port}"),
+		}
+	}
+}
+
+impl Display for SetParameter {
+	fn fmt(&self, fmt: &mut Formatter<'_>) -> FmtResult {
+		write!(fmt, "{}", Into::<&str>::into(self))
+	}
+}
+
+impl From<&SetParameter> for &str {
+	fn from(value: &SetParameter) -> Self {
+		match *value {
+			SetParameter::AtapiPort(_) => "atapi_port",
+		}
+	}
+}
+impl From<SetParameter> for &str {
+	fn from(value: SetParameter) -> Self {
+		Self::from(&value)
+	}
+}
+
 #[cfg(test)]
 mod unit_tests {
 	use super::*;

--- a/pkg/cat-dev/src/mion/proto/mod.rs
+++ b/pkg/cat-dev/src/mion/proto/mod.rs
@@ -8,12 +8,16 @@
 //!
 //! Each of these roughly correlate to one MION service, e.g.:
 //!
-//! - port 7974 is the "control" port, which can be used for discovery. So for
-//!   communicating on that port you access: [`crate::mion::proto::control`].
+//! - port 7974 UDP is the "control" port, which can be used for discovery. So
+//!   for communicating on that port you access:
+//!   [`crate::mion::proto::control`].
+//!   *note: some tools using session manager improperly use the ATAPI port
+//!   which while normally being shared just for the TCP side, can in theory
+//!   be configured differently.*
 //!
-//! - port 7978 on the other hand is used by `mionps` to look up parameters,
-//!   so we call it the "parameter" port, so you can access types for
-//!   communicating on that port under: [`crate::mion::proto::parameter`].
+//! - port 7978 TCP on the other hand is used by `mionps` to look up
+//!   parameters, so we call it the "parameter" port, so you can access types
+//!   for communicating on that port under: [`crate::mion::proto::parameter`].
 //!   The official tools don't have a way of specifying this port, but it is
 //!   actually configurable in `http://<mionip>/setup.cgi`. Specifically you
 //!   can change it under "Parameter Space".
@@ -23,7 +27,7 @@ pub mod control;
 pub mod parameter;
 
 /// The port the MION uses for 'control' commands.
-pub const MION_CONTROL_PORT: u16 = 7974;
+pub const DEFAULT_MION_CONTROL_PORT: u16 = 7974;
 /// The port the MION uses for parameter commands.
 pub const DEFAULT_MION_PARAMETER_PORT: u16 = 7978;
 


### PR DESCRIPTION
- bump version to 0.0.4
- allow configuring scan timeouts on every single `bridgectl` command
- add in buggy behavior to allow "configuring" the control port
  - the control port isn't actually configurable, but certain binaries *cough cough* FSEmul *cough cough* technically use the ATAPI port which is configurable. I'm 99.999999999% sure this is a bug, because:
    - changing the ATAPI port does not change the control port
    - the ATAPI port lines up with the control port by default
    - the code path where it uses this requires a tons of unique cases to be true.
- add in a very simple "boot without PCFS", that allows booting even when PCFS mode is turned on.
  - this is a very hacky implementation because PCFS/FSEmul is kicking my ass in figuring out all it does.
  - It does allow these devices to not become e-waste which is a huge step, even if RE-wise/technology-wise it's not a huge step.