### PR TITLE
update alt text in cat-dev readme

### DIFF
--- a/cmd/findbridge/src/output.rs
+++ b/cmd/findbridge/src/output.rs
@@ -110,6 +110,10 @@ Firmware version   : {}",
 	}
 }
 
+#[allow(
+	// False Positive generates bad code.
+	clippy::assigning_clones,
+)]
 fn print_identity_column_view(identity: &MionIdentity, is_detailed: bool, is_first: bool) {
 	if is_detailed {
 		println!();
@@ -152,6 +156,10 @@ fn print_identity_column_view(identity: &MionIdentity, is_detailed: bool, is_fir
 	}
 }
 
+#[allow(
+	// False Positive generates bad code.
+	clippy::assigning_clones,
+)]
 fn get_detailed_view_minus_extra_fields(identity: &MionIdentity) -> String {
 	let mut name = String::from(identity.name());
 	if name.len() > 32 {

--- a/pkg/cat-dev/README.md
+++ b/pkg/cat-dev/README.md
@@ -11,7 +11,7 @@ v2.12.13 -- you can look at the doc page at
 to find an image explaining this flow).
 
   <picture>
-    <image alt="A photo of a CAT-DEV v3 Console sitting in a makeshift container." width=640 height=480 src="https://c.reml.ink/images/github/sprig/cat-dev.jpg"></image>
+    <image alt="A photo of a CAT-DEV MP2 Console sitting in a makeshift container." width=640 height=480 src="https://c.reml.ink/images/github/sprig/cat-dev.jpg"></image>
   </picture>
 
 </div>

--- a/pkg/cat-dev/src/mion/discovery.rs
+++ b/pkg/cat-dev/src/mion/discovery.rs
@@ -460,7 +460,7 @@ pub enum MIONFindBy {
 	/// Search by a specific IP Address.
 	///
 	/// The IP Address has to be a V4 address, as the MIONs do not actually
-	/// support being on an IPv6 address, and using DHCPv6.
+	/// support being on an IPv6 address, and using `DHCPv6`.
 	///
 	/// This searching type will only send a specific request to the specific
 	/// IPv4 address that you've specified here. IT WILL NOT cause a full

--- a/pkg/log/README.md
+++ b/pkg/log/README.md
@@ -41,7 +41,7 @@ To enable this simply set the environment variable `SPRIG_TOKIO_CONSOLE_ADDR`
 to the network address you want the console to listen on. From this point on
 tokio-console will automatically be spun up and run.
 
-***If you are setting SPRIG_LOGGING, you must be sure to turn tokio/runtime up
+***If you are setting `SPRIG_LOGGING`, you must be sure to turn tokio/runtime up
 to trace for tokio-console to work! If you don't specify it, it will
 automatically be handled.***
 


### PR DESCRIPTION
was before i looked into what console type i had, never fixed it once i realized it was different. whoops. thanks GerbilSoft for the callout.