### PR TITLE
fix release builds

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -128,19 +128,19 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: sprig_unix_amd64.deb
-          path: installer-scripts/unix/sprig_0.0.9_amd64.deb
+          path: installer-scripts/unix/sprig_0.0.10_amd64.deb
       - uses: actions/upload-artifact@v4
         with:
           name: sprig_unix_amd64.rpm
-          path: installer-scripts/unix/sprig-0.0.9-1.x86_64.rpm
+          path: installer-scripts/unix/sprig-0.0.10-1.x86_64.rpm
       - uses: actions/upload-artifact@v4
         with:
           name: sprig_unix_amd64.apk
-          path: installer-scripts/unix/sprig_0.0.9_x86_64.apk
+          path: installer-scripts/unix/sprig_0.0.10_x86_64.apk
       - uses: actions/upload-artifact@v4
         with:
           name: sprig_unix_amd64.pkg.tar.zst
-          path: installer-scripts/unix/sprig-0.0.9-1-x86_64.pkg.tar.zst
+          path: installer-scripts/unix/sprig-0.0.10-1-x86_64.pkg.tar.zst
       - uses: actions/upload-artifact@v4
         with:
           name: sprig-target-directory-unix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,14 +238,14 @@ dependencies = [
 
 [[package]]
 name = "bridgectl"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "cat-dev",
  "clap",
  "fnv",
  "futures",
  "libc",
- "log 0.0.9",
+ "log 0.0.10",
  "mac_address",
  "miette",
  "terminal_size",
@@ -280,7 +280,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cat-dev"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "aes",
  "bitflags",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "catlog"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "tokio",
 ]
@@ -574,7 +574,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "findbridge"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "cat-dev",
  "mac_address",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "getbridgeconfig"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "cat-dev",
  "tokio",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "console-subscriber",
  "miette",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "mionparamspace"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "cat-dev",
  "time",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "mionps"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "cat-dev",
  "time",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "setbridgeconfig"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "cat-dev",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ authors = ["Cynthia <cynthia@coan.dev>"]
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rem-verse/sprig"
-version = "0.0.9"
+version = "0.0.10"
 
 [profile.release]
 codegen-units = 1

--- a/installer-scripts/osx/distribution.arm.xml
+++ b/installer-scripts/osx/distribution.arm.xml
@@ -12,5 +12,5 @@
   <choice id="sprig" title="sprig">
     <pkg-ref id="sprig.pkg"/>
   </choice>
-  <pkg-ref id="sprig.pkg" version="0.0.9" />
+  <pkg-ref id="sprig.pkg" version="0.0.10" />
 </installer-gui-script>

--- a/installer-scripts/osx/distribution.intel.xml
+++ b/installer-scripts/osx/distribution.intel.xml
@@ -12,5 +12,5 @@
   <choice id="sprig" title="sprig">
     <pkg-ref id="sprig.pkg"/>
   </choice>
-  <pkg-ref id="sprig.pkg" version="0.0.9" />
+  <pkg-ref id="sprig.pkg" version="0.0.10" />
 </installer-gui-script>

--- a/installer-scripts/osx/package.sh
+++ b/installer-scripts/osx/package.sh
@@ -32,7 +32,7 @@ cp ../../../LICENSE ./
 cd ../
 echo "Done! Building...."
 
-pkgbuild --root ./working-dir/ --identifier "dev.rem-verse.sprig" --version "0.0.9" --install-location "/usr/local/bin" sprig.pkg
+pkgbuild --root ./working-dir/ --identifier "dev.rem-verse.sprig" --version "0.0.10" --install-location "/usr/local/bin" sprig.pkg
 
 echo "Done! Preparing Distribution Directory..."
 mkdir working-dir-pkg

--- a/installer-scripts/unix/nfpm.yaml
+++ b/installer-scripts/unix/nfpm.yaml
@@ -6,7 +6,7 @@ homepage: "https://github.com/rem-verse/sprig"
 license: "MIT"
 maintainer: "Cynthia <cynthia@corp.rem-verse.email>"
 vendor: "RemVerse"
-version: "v0.0.9"
+version: "v0.0.10"
 
 arch: "amd64"
 platform: "linux"

--- a/installer-scripts/win/sprig.wxs
+++ b/installer-scripts/win/sprig.wxs
@@ -6,7 +6,7 @@
   <Package Manufacturer="RemVerse"
     Name="Sprig"
     Language="1033"
-    Version="0.0.9"
+    Version="0.0.10"
     UpgradeCode="f25b6ffc-5890-42f2-a1c1-0f7dd4a9ee11">
 
     <ui:WixUI Id="WixUI_Minimal" InstallDirectory="INSTALLFOLDER" />

--- a/pkg/cat-dev/src/fsemul/sdio/data_stream.rs
+++ b/pkg/cat-dev/src/fsemul/sdio/data_stream.rs
@@ -69,7 +69,8 @@ impl DataStream {
 					request_read_receiver,
 					read_response_sender,
 					send_bytes_receiver,
-					#[cfg(debug_assertions)] trace_io,
+					#[cfg(debug_assertions)]
+					trace_io,
 				)
 				.instrument(error_span!(
 				  "FSEmulSDIOClientDataStream",
@@ -128,7 +129,8 @@ impl DataStream {
 					request_read_receiver,
 					read_response_sender,
 					send_bytes_receiver,
-					#[cfg(debug_assertions)] trace_io,
+					#[cfg(debug_assertions)]
+					trace_io,
 				)
 				.instrument(error_span!(
 				  "FSEmulSDIOServerDataStream",

--- a/pkg/cat-dev/src/fsemul/sdio/data_stream.rs
+++ b/pkg/cat-dev/src/fsemul/sdio/data_stream.rs
@@ -22,7 +22,10 @@ use tokio::{
 	task::Builder as TaskBuilder,
 	time::sleep,
 };
-use tracing::{Instrument, debug, error, error_span};
+use tracing::{Instrument, error, error_span};
+
+#[cfg(debug_assertions)]
+use tracing::debug;
 
 /// A connection to a "data stream" for SDIO.
 ///
@@ -66,7 +69,7 @@ impl DataStream {
 					request_read_receiver,
 					read_response_sender,
 					send_bytes_receiver,
-					trace_io,
+					#[cfg(debug_assertions)] trace_io,
 				)
 				.instrument(error_span!(
 				  "FSEmulSDIOClientDataStream",
@@ -125,7 +128,7 @@ impl DataStream {
 					request_read_receiver,
 					read_response_sender,
 					send_bytes_receiver,
-					trace_io,
+					#[cfg(debug_assertions)] trace_io,
 				)
 				.instrument(error_span!(
 				  "FSEmulSDIOServerDataStream",

--- a/pkg/cat-dev/src/fsemul/sdio/server/mod.rs
+++ b/pkg/cat-dev/src/fsemul/sdio/server/mod.rs
@@ -210,8 +210,7 @@ impl SDIOStreamState {
 		data_port: u16,
 		host_fs: HostFilesystem,
 		cat_dev_sleep: Option<Duration>,
-		#[cfg(debug_assertions)]
-		trace_during_debug: bool,
+		#[cfg(debug_assertions)] trace_during_debug: bool,
 	) -> Self {
 		Self {
 			chunk_size,

--- a/pkg/cat-dev/src/fsemul/sdio/server/mod.rs
+++ b/pkg/cat-dev/src/fsemul/sdio/server/mod.rs
@@ -106,6 +106,7 @@ pub async fn sdio_server(
 			} else {
 				Some(cat_dev_sleep_override.unwrap_or(DEFAULT_CAT_DEV_SLOWDOWN))
 			},
+			#[cfg(debug_assertions)]
 			trace_during_debug,
 		),
 		trace_during_debug,
@@ -147,6 +148,7 @@ async fn on_sdio_stream_begin(
 		addr,
 		event.state().cat_dev_slowdown,
 		event.state().chunk_size,
+		#[cfg(debug_assertions)]
 		event.state().trace_during_debug,
 	)
 	.await?;
@@ -197,6 +199,7 @@ pub struct SDIOStreamState {
 	/// The host filesystem that actually contains pointers to the filesystem.
 	host_fs: HostFilesystem,
 	/// Trace when debug mode is active.
+	#[cfg(debug_assertions)]
 	trace_during_debug: bool,
 }
 
@@ -207,6 +210,7 @@ impl SDIOStreamState {
 		data_port: u16,
 		host_fs: HostFilesystem,
 		cat_dev_sleep: Option<Duration>,
+		#[cfg(debug_assertions)]
 		trace_during_debug: bool,
 	) -> Self {
 		Self {
@@ -214,6 +218,7 @@ impl SDIOStreamState {
 			cat_dev_slowdown: cat_dev_sleep,
 			data_port,
 			host_fs,
+			#[cfg(debug_assertions)]
 			trace_during_debug,
 		}
 	}

--- a/pkg/cat-dev/src/net/mod.rs
+++ b/pkg/cat-dev/src/net/mod.rs
@@ -19,10 +19,12 @@ pub use ext_map::Extensions;
 #[cfg(test)]
 use std::sync::RwLock;
 use std::{
-	env::var as env_var,
-	sync::{LazyLock, atomic::AtomicU64},
+	sync::atomic::AtomicU64,
 	time::{Duration, SystemTime},
 };
+
+#[cfg(debug_assertions)]
+use std::{env::var as env_var, sync::LazyLock};
 
 /// The default slowdown to use for cat-dev units that seems to work.
 pub const DEFAULT_CAT_DEV_SLOWDOWN: Duration = Duration::from_millis(25);
@@ -37,6 +39,7 @@ static STREAM_ID: AtomicU64 = AtomicU64::new(1);
 static TCP_READ_BUFFER_SIZE: usize = 65536_usize;
 
 /// If we should be tracing IO regardless of what the user says.
+#[cfg(debug_assertions)]
 static SPRIG_TRACE_IO: LazyLock<bool> = LazyLock::new(|| {
 	if let Ok(variable) = env_var("SPRIG_FORCE_TRACE_ALL_IO") {
 		variable != "0" && !variable.is_empty()


### PR DESCRIPTION
this guards more of the tracing with `#[cfg(debug_assertions)]`, oops!

also do a version bump since i had started publishing 0.0.9 before realizing rel builds were broken.